### PR TITLE
Create Junie extension with .NET 10 and C# 14 best practices

### DIFF
--- a/.junie-extension/marketplace.json
+++ b/.junie-extension/marketplace.json
@@ -172,6 +172,25 @@
         "mobile-mcp",
         "adb"
       ]
+    },
+    {
+      "name": "dotnet-10-best-practices",
+      "source": "./extensions/dotnet-10-best-practices",
+      "description": "C# 14 / .NET 10 migration & best practices — TFM upgrades, ASP.NET Core 10 (Minimal API validation, native OpenAPI 3.1), C# 14 language features (Extension Members, field keyword), performance wins (LINQ, System.Text.Json source gen, sealed-by-default), and third-party library upgrade traps (FluentFTP, Silverback/Kafka).",
+      "version": "1.0.0",
+      "author": {
+        "name": "JetBrains"
+      },
+      "category": "language",
+      "homepage": "https://github.com/JetBrains/junie-extensions/tree/main/extensions/dotnet-10-best-practices",
+      "keywords": [
+        "dotnet",
+        "dotnet10",
+        "csharp",
+        "csharp14",
+        "aspnetcore",
+        "migration"
+      ]
     }
   ]
 }

--- a/extensions/dotnet-10-best-practices/README.md
+++ b/extensions/dotnet-10-best-practices/README.md
@@ -1,0 +1,38 @@
+# dotnet-10-best-practices
+
+Junie extension that turns the agent into a disciplined .NET 10 / C# 14 engineer: applies the mechanical migration steps correctly, adopts new language and runtime features where they pay off, and catches the third-party breaking changes that LLMs get wrong by default — assuming `FluentFTP`'s async methods kept their `Async` suffix, missing that OpenAPI 3.1 is now the default, or sealing the wrong classes.
+
+## Philosophy
+
+Baseline .NET and C# knowledge is assumed — the extension does not re-teach the language. Instead it encodes:
+
+- **Migration mechanics** — the exact `.csproj`, Dockerfile, CI pipeline, and NuGet changes required to move a solution to `net10.0`.
+- **New language/runtime features** — C# 14 additions (Extension Members, `field` keyword, and more) and .NET 10 performance wins, with guidance on when they're worth adopting.
+- **Breaking-change awareness** — real, documented breaking changes in the framework and in commonly-used third-party libraries (FluentFTP, OpenTelemetry, Silverback), so upgrades don't silently regress.
+
+## What it covers
+
+- TFM and `.csproj` updates, including the `$(Configuration)`/`$(TargetFramework)` pattern for `DocumentationFile`.
+- C# 14: Extension Members, the `field` keyword, null-conditional assignment, lambda parameter modifiers, implicit `Span<T>` conversions, partial constructors, user-defined compound operators, improved `nameof`.
+- ASP.NET Core 10: built-in Minimal API validation, native OpenAPI 3.1 generation (Scalar/Swagger UI), the `WithOpenApi()` deprecation, passkey support, Blazor `QuickGrid` improvements.
+- Performance: LINQ abstraction-overhead reduction, `System.Text.Json` source generators, JIT devirtualization, NativeAOT, `TimeProvider`, and a "sealed by default" policy with the `CA1852` analyzer.
+- Dockerfile/CI/Helm updates for .NET 10's Ubuntu-based (no `-jammy`) official images.
+- Known third-party breaking changes: OpenTelemetry's `SetDbStatementForText` removal, FluentFTP 53's `Async`-suffix removal, and the Silverback 4.x → 5.x Kafka messaging rewrite.
+
+## Files
+
+- `skills/dotnet10-best-practices/SKILL.md` — hub: Setup Check, Key Patterns, Constraints (MUST DO / MUST NOT DO), Reference Guide, Output Format.
+- `skills/dotnet10-best-practices/references/csharp-14-features.md` — Extension Members, `field` keyword, and the rest of the C# 14 language additions.
+- `skills/dotnet10-best-practices/references/minimal-apis.md` — ASP.NET Core 10: Minimal API validation, native OpenAPI 3.1, passkeys, Blazor.
+- `skills/dotnet10-best-practices/references/performance.md` — LINQ/JSON/JIT/NativeAOT performance, `TimeProvider`, sealed-by-default guidance.
+- `skills/dotnet10-best-practices/references/csproj-and-build.md` — `.csproj`, NuGet, Dockerfile, CI pipeline, and Helm migration steps plus known breaking changes.
+- `skills/dotnet10-best-practices/references/messaging-patterns.md` — Silverback 4.x → 5.x Kafka messaging migration guide.
+
+## Requirements
+
+- .NET 10 SDK.
+- A C# 14-capable compiler (ships with the .NET 10 SDK).
+
+## Installation
+
+Drop the extension folder into your Junie extensions directory and enable it. Junie picks up `SKILL.md` automatically and loads references on demand.

--- a/extensions/dotnet-10-best-practices/extension.json
+++ b/extensions/dotnet-10-best-practices/extension.json
@@ -1,0 +1,4 @@
+{
+  "name": "dotnet-10-best-practices",
+  "description": "C# 14 / .NET 10 migration & best practices — TFM upgrades, ASP.NET Core 10 (Minimal API validation, native OpenAPI 3.1), C# 14 language features (Extension Members, field keyword), performance wins (LINQ, System.Text.Json source gen, sealed-by-default), and third-party library upgrade traps (FluentFTP, Silverback/Kafka)."
+}

--- a/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/SKILL.md
+++ b/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: "dotnet10-best-practices"
+description: ".NET 10 / C# 14 migration & best practices — TFM upgrades, ASP.NET Core 10 (Minimal API validation, native OpenAPI 3.1), C# 14 language features (Extension Members, field keyword), sealed-by-default performance guidance, and real third-party breaking changes (FluentFTP, Silverback/Kafka). Use when migrating a project to .NET 10, writing C# 14 code, or reviewing a .csproj/Dockerfile/pipeline update."
+---
+
+# .NET 10 / C# 14 — migration & best practices
+
+Baseline .NET/C# knowledge is assumed. This skill encodes the concrete migration steps, new C# 14 language features, and the breaking changes that trip up both LLMs and humans when moving a project from .NET 8 to .NET 10.
+
+## Setup Check (run first)
+
+Before touching a project's migration:
+
+1. **Current TFM** — check every `.csproj` in the solution; multi-project solutions (API, Application, Domain, Infrastructure, Tests, ...) must all move to `net10.0` together.
+2. **Third-party dependencies** — check each major dependency's own changelog for the version jump you're making (see `references/csproj-and-build.md` for known traps in OpenTelemetry and FluentFTP, and `references/messaging-patterns.md` for Silverback).
+3. **CI/CD and containers** — Dockerfile base images and CI pipeline SDK version pins need matching updates; .NET 10's official images dropped the `-jammy` suffix.
+4. **OpenAPI tooling** — .NET 10 defaults to OpenAPI 3.1; check whether client generators or API gateways downstream still expect 3.0.
+
+## Key Patterns
+
+**TFM bump** (repeat in every `.csproj`):
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net10.0</TargetFramework>
+</PropertyGroup>
+```
+
+**`field` keyword** — validation/transformation without an explicit backing field:
+
+```csharp
+public string Host
+{
+    get;
+    set => field = value ?? throw new ArgumentNullException(nameof(value));
+}
+```
+
+**Sealed by default:**
+
+```csharp
+public sealed class OrderService(IOrderRepository repository) : IOrderService { }
+```
+
+**Minimal API built-in validation:**
+
+```csharp
+public class UploadRequest
+{
+    [Required] public string SystemCode { get; set; }
+}
+
+app.MapPost("/api/upload", (UploadRequest request) => Results.Ok()); // validated automatically
+```
+
+## Constraints
+
+**MUST DO:**
+
+- Move **every** `.csproj` in a solution to `net10.0` together — a mixed-TFM solution breaks project references.
+- Use `$(Configuration)`/`$(TargetFramework)` MSBuild variables in `DocumentationFile` and similar paths instead of hardcoding the framework version.
+- Check each third-party dependency's own breaking-change notes before bumping its major version alongside the framework — a framework migration is not a safe time to also blind-bump unrelated packages.
+- Default new classes to `sealed` unless the class is explicitly designed for inheritance; mock via an interface, not the concrete class.
+- Verify whether downstream tooling (client generators, gateways) can consume OpenAPI 3.1 before relying on .NET 10's new default.
+
+**MUST NOT DO:**
+
+- MUST NOT assume a third-party library's method names are unchanged across a major version bump — e.g. FluentFTP 53 dropped the `Async` suffix from `AsyncFtpClient` methods while keeping them asynchronous.
+- MUST NOT keep `-jammy`-suffixed Docker base image tags when moving to .NET 10 — the official images dropped that suffix and the old tag may not exist.
+- MUST NOT hardcode NuGet package versions without checking what's actually compatible with the target framework — version claims go stale fast.
+- MUST NOT seal a class that is part of a planned inheritance hierarchy, or an `abstract class` meant to be a base type.
+- MUST NOT upgrade Silverback to 5.x on a project still using RabbitMQ through it — RabbitMQ support was dropped in that release.
+
+## Reference Guide
+
+| Load when                                                                                                                                                   | File                               |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| Writing or reviewing C# 14 code (Extension Members, `field` keyword, lambda modifiers, partial constructors, implicit `Span<T>`, custom compound operators) | `references/csharp-14-features.md` |
+| Building or reviewing Minimal API endpoints, OpenAPI/Scalar setup, or Blazor `QuickGrid` usage on ASP.NET Core 10                                           | `references/minimal-apis.md`       |
+| Evaluating performance-sensitive code, `System.Text.Json` source generators, or `sealed`/`TimeProvider` design                                              | `references/performance.md`        |
+| Performing the mechanical migration: `.csproj` TFM bump, NuGet version updates, Dockerfile/CI/Helm changes, known breaking changes                          | `references/csproj-and-build.md`   |
+| Upgrading Silverback (Kafka messaging) alongside a .NET 10 migration                                                                                        | `references/messaging-patterns.md` |
+
+## Output Format
+
+When performing or reviewing a migration step:
+
+1. Short plan (1–3 bullets) — which files/packages/config are touched and why.
+2. The diff (before/after), matching the style in the relevant reference file.
+3. Call out any breaking change the step depends on, and where to verify it (changelog, `dotnet list package`, `EXPLAIN`-equivalent for the dependency in question).
+4. If the step is part of a checklist in a reference file, point to it instead of re-deriving the checklist inline.

--- a/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/references/csharp-14-features.md
+++ b/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/references/csharp-14-features.md
@@ -1,0 +1,401 @@
+# C# 14 Language Features
+
+Detailed reference for the new C# 14 language features shipped with .NET 10. Load this when writing or reviewing code that could benefit from Extension Members, the `field` keyword, or the other additions below.
+
+## Extension Members
+
+C# 14 replaces the traditional `this`-parameter extension method with an `extension` block that names the target type once and lets you declare methods, properties, operators, and static members with a unified syntax.
+
+**Before (C# 12 / traditional extension methods):**
+
+```csharp
+public static class StringExtensions
+{
+    public static bool IsNullOrEmpty(this string value)
+    {
+        return string.IsNullOrEmpty(value);
+    }
+
+    public static string Truncate(this string value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length <= maxLength)
+            return value;
+        return value.Substring(0, maxLength);
+    }
+}
+```
+
+**After (C# 14 / extension members):**
+
+```csharp
+public static class StringExtensions
+{
+    extension(string value)
+    {
+        public bool IsNullOrEmpty => string.IsNullOrEmpty(value);
+
+        public string Truncate(int maxLength)
+        {
+            if (string.IsNullOrEmpty(value) || value.Length <= maxLength)
+                return value;
+            return value.Substring(0, maxLength);
+        }
+    }
+}
+```
+
+Call sites are unchanged: `"text".IsNullOrEmpty` or `"text".Truncate(5)`.
+
+### Extension properties
+
+Before C# 14 it was not possible to declare an extension _property_. Now it is:
+
+```csharp
+public static class EnumerableExtensions
+{
+    extension<TSource>(IEnumerable<TSource> source)
+    {
+        public bool IsEmpty => !source.Any();
+
+        public int SafeCount => source?.Count() ?? 0;
+    }
+}
+
+// Usage:
+int[] data = [1, 2, 3];
+if (data.IsEmpty)
+{
+    // ...
+}
+```
+
+### Static extension members and operators
+
+Static members and operators can be added to the extended type inside the same block:
+
+```csharp
+public static class EnumerableExtensions
+{
+    extension<TSource>(IEnumerable<TSource> source)
+    {
+        // Static member
+        public static IEnumerable<TSource> Identity => Enumerable.Empty<TSource>();
+
+        // Extension operator
+        public static IEnumerable<TSource> operator +(
+            IEnumerable<TSource> left,
+            IEnumerable<TSource> right) => left.Concat(right);
+    }
+}
+
+// Usage:
+var combined = data + [4, 5];
+var empty = IEnumerable<int>.Identity;
+```
+
+### Practical example: extending a domain entity
+
+```csharp
+public static class FileRecordExtensions
+{
+    extension(FileRecord file)
+    {
+        public bool HasFile => file != null && !string.IsNullOrEmpty(file.FileId.ToString());
+
+        public string FullPath => $"{file.Directory}{file.FileId}{file.Extension}";
+
+        public string PublicUrl(string baseUrl)
+        {
+            var dir = file.Directory.Replace("/data/", "");
+            return $"{baseUrl}{dir}{file.FileId}{file.Extension}";
+        }
+    }
+}
+```
+
+### Compatibility
+
+- Extension members compile to the **same IL** as traditional extension methods.
+- They are **source and binary compatible** — migrate one method at a time.
+- Code that already calls your extension methods **does not need to change**.
+
+### When to use
+
+- You have **multiple** extension methods for the same type.
+- You want to add **properties** as extensions (impossible before C# 14).
+- You want to group a type's extensions logically.
+
+### When NOT to use
+
+- A single, isolated extension method — the traditional form is simpler.
+- The project still needs to support a pre-C# 14 compiler.
+
+## `field` keyword
+
+C# 14 introduces the contextual keyword `field`, which gives direct access to the compiler-generated backing field of an auto-property without declaring a private field by hand.
+
+**The problem (before C# 14):** any property that needs validation or setter logic requires an explicit backing field.
+
+```csharp
+public class ServiceConfig
+{
+    private string _host;
+
+    public string Host
+    {
+        get => _host;
+        set => _host = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    private int _port;
+
+    public int Port
+    {
+        get => _port;
+        set => _port = value > 0
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value));
+    }
+
+    private int _retries;
+
+    public int Retries
+    {
+        get => _retries;
+        set => _retries = Math.Clamp(value, 1, 10);
+    }
+}
+```
+
+**The solution (C# 14):** the compiler generates the backing field for you, accessible via `field`.
+
+```csharp
+public class ServiceConfig
+{
+    public string Host
+    {
+        get;
+        set => field = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public int Port
+    {
+        get;
+        set => field = value > 0
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value));
+    }
+
+    public int Retries
+    {
+        get;
+        set => field = Math.Clamp(value, 1, 10);
+    }
+}
+```
+
+Result: less boilerplate, identical behavior — the explicit `_host`/`_port`/`_retries` fields disappear.
+
+### Practical example: DTO with validation
+
+```csharp
+public class UploadRequest
+{
+    public string SystemCode
+    {
+        get;
+        set => field = !string.IsNullOrWhiteSpace(value)
+            ? value.Trim().ToUpper()
+            : throw new ArgumentException("System code is required");
+    }
+
+    public string Extension
+    {
+        get;
+        set => field = value?.StartsWith('.') == true
+            ? value
+            : $".{value}";
+    }
+
+    public byte[] Data
+    {
+        get;
+        set => field = value?.Length > 0
+            ? value
+            : throw new ArgumentException("File data is required");
+    }
+}
+```
+
+### Example: lazy initialization
+
+```csharp
+public class ServiceSettings
+{
+    public string ConnectionString
+    {
+        get => field ??= LoadFromEnvironment();
+        set;
+    }
+
+    private static string LoadFromEnvironment()
+        => Environment.GetEnvironmentVariable("CONNECTION_STRING") ?? "";
+}
+```
+
+### Important characteristics
+
+- `field` can only be used inside a property's **getter and setter**.
+- It is a **contextual keyword** — it does not break code that already declares a variable named `field`.
+- The generated backing field is **not accessible** outside the accessor (better encapsulation than a private `_field`).
+- No change to generated IL — it is purely a compile-time convenience.
+
+### When to use
+
+- Properties that need **setter validation**.
+- Properties with **value transformation** (trim, clamp, normalization).
+- **Lazy initialization** with `??=`.
+- Any case where you would otherwise declare a private `_field` solely for the getter/setter.
+
+### When NOT to use
+
+- Plain auto-properties with no logic (`public string Name { get; set; }` already works without `field`).
+- When the field must be accessed **outside the property** — keep the explicit field in that case.
+
+## Other C# 14 additions
+
+### Null-conditional assignment
+
+Safely assign to a property of a possibly-null object.
+
+**Before:**
+
+```csharp
+if (file != null)
+{
+    file.ReturnUrl = url;
+}
+```
+
+**After:**
+
+```csharp
+file?.ReturnUrl = url;
+```
+
+### Lambda parameter modifiers
+
+Lambdas now support `params`, `ref`, `in`, and `out` on their parameters.
+
+**Before:**
+
+```csharp
+// params was not allowed on a lambda
+Func<int[], int> sum = (int[] numbers) => numbers.Sum();
+```
+
+**After:**
+
+```csharp
+var sum = (params int[] numbers) => numbers.Sum();
+
+// Usage:
+int result = sum(1, 2, 3, 4, 5);
+```
+
+### Implicit `Span<T>` conversions
+
+`Span<T>` and `ReadOnlySpan<T>` now convert implicitly in more scenarios, reducing the need to call `.AsSpan()` explicitly.
+
+**Before:**
+
+```csharp
+void ProcessData(ReadOnlySpan<byte> data) { }
+
+byte[] buffer = new byte[1024];
+ProcessData(buffer.AsSpan());  // .AsSpan() required
+```
+
+**After:**
+
+```csharp
+void ProcessData(ReadOnlySpan<byte> data) { }
+
+byte[] buffer = new byte[1024];
+ProcessData(buffer);  // implicit conversion
+```
+
+> In overload-resolution scenarios the chosen overload can change. If there's ambiguity, use an explicit cast.
+
+### Partial constructors
+
+Constructors can now be `partial`, splitting initialization logic across files.
+
+```csharp
+// File: OrderService.cs
+public partial class OrderService
+{
+    public partial OrderService(IOrderRepository repository, IMessagePublisher messaging);
+}
+
+// File: OrderService.Init.cs
+public partial class OrderService
+{
+    public partial OrderService(IOrderRepository repository, IMessagePublisher messaging)
+    {
+        _repository = repository;
+        _messaging = messaging;
+    }
+}
+```
+
+### User-defined compound operators
+
+You can now define `+=`, `-=`, and other compound operators directly, without relying on the base binary operator.
+
+```csharp
+public class Counter
+{
+    public int Value { get; private set; }
+
+    public static Counter operator +=(Counter c, int increment)
+    {
+        c.Value += increment;
+        return c;
+    }
+}
+
+// Usage:
+var counter = new Counter();
+counter += 5;
+```
+
+### Improved `nameof`
+
+`nameof` now works in more contexts, including attribute arguments and members of open generic types.
+
+**Before:**
+
+```csharp
+// Not allowed in some attribute contexts
+[Display(Name = "UserName")]
+public string UserName { get; set; }
+```
+
+**After:**
+
+```csharp
+[Display(Name = nameof(UserName))]
+public string UserName { get; set; }
+```
+
+### Summary
+
+| Feature                         | Main benefit                   |
+| ------------------------------- | ------------------------------ |
+| Null-conditional assignment     | Fewer `if (x != null)` guards  |
+| Lambda parameter modifiers      | More flexible lambdas          |
+| Implicit Span conversion        | Fewer manual `.AsSpan()` calls |
+| Partial constructors            | Better code organization       |
+| User-defined compound operators | More ergonomic custom types    |
+| Improved `nameof`               | Fewer hardcoded strings        |

--- a/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/references/csproj-and-build.md
+++ b/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/references/csproj-and-build.md
@@ -1,0 +1,300 @@
+# Project File, Dependencies & Build/Deploy Updates
+
+Reference for mechanically updating `.csproj` files, NuGet dependencies, and CI/CD configuration when migrating a project to .NET 10. Load this when performing or reviewing the actual migration steps (as opposed to adopting new language/runtime features).
+
+## Target Framework Moniker (TFM)
+
+In **every** `.csproj` file of a multi-project solution (API, Application, Domain, Infrastructure, Repository, Services, Tests, ...), update the target framework:
+
+**Before:**
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net8.0</TargetFramework>
+</PropertyGroup>
+```
+
+**After:**
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net10.0</TargetFramework>
+</PropertyGroup>
+```
+
+> **Why:** this tells the compiler to use the .NET 10 SDK and libraries.
+
+## `DocumentationFile`
+
+Do not hardcode the framework version in the `DocumentationFile` path. Use MSBuild variables so the path adapts automatically in future migrations.
+
+**Before:**
+
+```xml
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <DocumentationFile>bin\Debug\net8.0\Api.xml</DocumentationFile>
+  <NoWarn>1591</NoWarn>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <DocumentationFile>bin\Release\net8.0\Api.xml</DocumentationFile>
+</PropertyGroup>
+```
+
+**After:**
+
+```xml
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Api.xml</DocumentationFile>
+  <NoWarn>1591</NoWarn>
+</PropertyGroup>
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Api.xml</DocumentationFile>
+</PropertyGroup>
+```
+
+> **Why:** using `$(Configuration)` and `$(TargetFramework)`, the path adjusts automatically on framework or configuration changes, avoiding manual edits in future migrations.
+
+## Removing an unnecessary `OutputPath`
+
+If the Release block has an empty `<OutputPath />`, it can be removed — it has no effect:
+
+**Remove:**
+
+```xml
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Api.xml</DocumentationFile>
+  <OutputPath />
+</PropertyGroup>
+```
+
+**Keep:**
+
+```xml
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Api.xml</DocumentationFile>
+</PropertyGroup>
+```
+
+## Checklist: project files
+
+- [ ] Change `TargetFramework` to `net10.0` in **all** `.csproj` files
+- [ ] Replace hardcoded `DocumentationFile` paths with `$(Configuration)\$(TargetFramework)`
+- [ ] Remove an empty `<OutputPath />` if present
+- [ ] Run `dotnet build` to validate
+
+## NuGet Dependency Updates
+
+### General rule
+
+Do not bump package versions arbitrarily. Check the compatibility notes for each dependency, and keep an internal reference (a wiki page, an `.editorconfig`, or a central `Directory.Packages.props`) of the versions homologated for the target framework across the organization's projects.
+
+### External packages
+
+**Before (.NET 8):**
+
+```xml
+<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.16" />
+<PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.1" />
+<PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.12.0-beta.1" />
+<PackageReference Include="FluentFTP" Version="40.0.0" />
+```
+
+**After (.NET 10):**
+
+```xml
+<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
+<PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.0" />
+<PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.0-beta.1" />
+<PackageReference Include="FluentFTP" Version="53.0.2" />
+```
+
+### Test packages
+
+**Before:**
+
+```xml
+<PackageReference Include="coverlet.collector" Version="6.0.4" />
+<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+<PackageReference Include="xunit" Version="2.9.3" />
+<PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />
+```
+
+**After:**
+
+```xml
+<PackageReference Include="coverlet.collector" Version="8.0.0" />
+<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+<PackageReference Include="xunit" Version="2.9.3" />
+<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+```
+
+### Verifying installed versions
+
+```bash
+dotnet list package
+```
+
+### Checklist: dependencies
+
+- [ ] Update external packages to the versions homologated for .NET 10
+- [ ] Update test packages
+- [ ] Run `dotnet restore` and `dotnet build` to validate
+
+## Known Third-Party Breaking Changes
+
+### OpenTelemetry: `SetDbStatementForText` removed
+
+`SetDbStatementForText` was removed/deprecated in OpenTelemetry 1.12+. Remove the call.
+
+**Before:**
+
+```csharp
+options.SetDbStatementForText = true;
+```
+
+**After:** delete the line. The default behavior already covers this scenario.
+
+### FluentFTP 53: methods drop the `Async` suffix
+
+`AsyncFtpClient` in FluentFTP 53 removed the `Async` suffix from its methods. **They are still asynchronous** (they return `Task`), only the names changed.
+
+**Before (FluentFTP 40):**
+
+```csharp
+var client = new AsyncFtpClient(host, user, pass);
+await client.ConnectAsync(cancellationToken);
+await client.DeleteFileAsync(path, cancellationToken);
+await client.UploadFileAsync(localPath, remotePath, FtpRemoteExists.Overwrite);
+await client.FileExistsAsync(path, cancellationToken);
+await client.CreateDirectoryAsync(path, cancellationToken);
+await client.DownloadBytesAsync(path, cancellationToken);
+await client.DisconnectAsync(cancellationToken);
+```
+
+**After (FluentFTP 53):**
+
+```csharp
+var client = new AsyncFtpClient(host, user, pass);
+await client.Connect(cancellationToken);
+await client.DeleteFile(path, cancellationToken);
+await client.UploadFile(localPath, remotePath, FtpRemoteExists.Overwrite);
+await client.FileExists(path, cancellationToken);
+await client.CreateDirectory(path, cancellationToken);
+await client.DownloadBytes(path, cancellationToken);
+await client.Disconnect(cancellationToken);
+```
+
+> All methods return `Task` and must be `await`ed. `AsyncFtpClient` exposes **only** async operations; the synchronous `FtpClient` exists as a separate class.
+
+### Internal shared libraries: watch for breaking changes on major jumps
+
+If your organization maintains internal shared packages (a common auth/logging/messaging kernel, etc.), a .NET 10 migration is a natural point where those packages also jump major versions. Treat any such jump like a third-party breaking change: read the changelog, check for namespace moves or signature changes, and don't assume the public API is unchanged just because the package is "internal."
+
+### Test package major-version jumps
+
+Test tooling packages had major version jumps in this cycle. Verify compatibility:
+
+- `coverlet.collector`: 6.x → **8.0.0**
+- `Microsoft.NET.Test.Sdk`: 17.x → **18.3.0**
+- `xunit.runner.visualstudio`: 3.1.3 → **3.1.5**
+
+## Other .NET 10 Breaking Changes
+
+- **Docker images** now use Ubuntu by default (no `-jammy` suffix).
+- **C# 14**: `Span<T>` overload resolution may require an explicit cast in ambiguous scenarios.
+- **`BufferedStream.WriteByte`** no longer performs an implicit flush.
+- **`FilePatternMatch.Stem`** is now non-nullable.
+- **Default trace-context propagator** changed to W3C.
+
+## Docker & CI/CD Updates
+
+### Dockerfile
+
+.NET base images must be bumped to `10.0`. In .NET 10, the official images **no longer use the `-jammy` suffix**.
+
+**Before (.NET 8):**
+
+```dockerfile
+ARG DOTNET_VER=8.0
+
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VER}-jammy AS base
+
+RUN groupadd -g 1000 appgroup && \
+    useradd -u 1000 -g appgroup -s /bin/bash appuser
+
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VER}-jammy AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore
+RUN dotnet publish -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+USER appuser
+ENTRYPOINT ["dotnet", "my-api.dll"]
+```
+
+**After (.NET 10):**
+
+```dockerfile
+ARG DOTNET_VER=10.0
+
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VER} AS base
+
+RUN groupadd -g 10000 appgroup && \
+    useradd -u 10000 -g appgroup -s /bin/bash appuser
+
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VER} AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore
+RUN dotnet publish -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+USER appuser
+ENTRYPOINT ["dotnet", "my-api.dll"]
+```
+
+#### Key changes
+
+| Item         | Before             | After                                                |
+| ------------ | ------------------ | ---------------------------------------------------- |
+| `DOTNET_VER` | `8.0`              | `10.0`                                               |
+| Base image   | `aspnet:8.0-jammy` | `aspnet:10.0` (no `-jammy`)                          |
+| SDK image    | `sdk:8.0-jammy`    | `sdk:10.0` (no `-jammy`)                             |
+| UID/GID      | `1000`             | `10000` (or any convention your org standardizes on) |
+
+> .NET 10 uses Ubuntu by default in the official images. The `-jammy` suffix is no longer needed and can cause errors if that tag doesn't exist.
+
+### CI pipeline
+
+Update the .NET SDK version used by your pipeline's build tasks — for example, in Azure Pipelines:
+
+```yaml
+variables:
+  dotnetVersion: "10.0"
+```
+
+The same principle applies to any other CI system (GitHub Actions, GitLab CI, Jenkins): whatever variable pins the SDK/runtime version needs to move to `10.0`.
+
+### Helm chart `values.yaml`
+
+If `values.yaml` pins the Docker image tag, update it to point at the .NET 10 image built by the pipeline.
+
+### Checklist: build & deploy
+
+- [ ] Update `DOTNET_VER` to `10.0` in the Dockerfile
+- [ ] Remove the `-jammy` suffix from images
+- [ ] Update the UID/GID convention if applicable
+- [ ] Update the SDK version variable in the CI pipeline
+- [ ] Update the image tag in Helm/`values.yaml` if applicable
+- [ ] Test the container build locally

--- a/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/references/messaging-patterns.md
+++ b/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/references/messaging-patterns.md
@@ -1,0 +1,161 @@
+# Messaging: Silverback 4.x → 5.x Migration (Kafka)
+
+[Silverback](https://silverback-messaging.net/) is a popular .NET message-bus library for Kafka/RabbitMQ. Its 5.x release is described by the maintainers as "the most significant update in the project's history," with major API and architecture changes. Load this reference when upgrading a project's Silverback dependency alongside a .NET 10 migration, or when evaluating whether to adopt Silverback for a new Kafka-based service.
+
+## When to Upgrade
+
+Whether to move to Silverback 5.x depends heavily on how much the codebase relies on the library's advanced features (outbox pattern, EF Core integration, endpoint configuration, publishers, etc.).
+
+✅ **Upgrade if:**
+
+- The project already targets `net10`.
+- The service consumes a high amount of memory relative to its messaging load.
+- You're starting a new project.
+
+⚠️ **Don't upgrade if:**
+
+- The project still targets `net6` or `net8` — Silverback 5.x requires `net10`.
+- Memory usage isn't a concern.
+- The project uses **RabbitMQ** through Silverback — RabbitMQ support was dropped in v5.
+- The refactoring cost is too high given the breaking changes below.
+
+## Advantages of 5.x
+
+- **Better performance and fewer allocations** — the library was refactored to reduce allocations and improve message-processing performance.
+- **Simpler `IPublisher`** — most visible when using the Message Bus pattern. `CancellationToken` support was added in this release.
+- **`IPublisher` is now `Transient`** — it used to be `Scoped`, so it can now be injected into `Singleton` services. This resolves issues like publishers being cached in singleton pipelines.
+- **Better Kafka support** — Kafka transactions, client-side offset storage, partition assignment, and schema registry support. Relevant if you use Kafka Streams.
+- **Better serialization support** — the default serializer is now `System.Text.Json`. See the [Silverback deserialization docs](https://silverback-messaging.net/guides/broker/consuming/deserialization.html) for pipeline configuration details.
+
+## Disadvantages / Breaking Changes
+
+- **No compatibility with older .NET versions** — 5.x only supports projects already on `net10`.
+- **Large number of breaking changes** — the configuration surface was completely rewritten: APIs were renamed, namespaces changed, and endpoint models rewritten.
+- **RabbitMQ support removed** — if a project uses the `Silverback.Integration.RabbitMQ` namespace, do not upgrade until an alternative is in place.
+
+### Configuration rewrite example
+
+**Before (4.x):**
+
+```csharp
+services
+    .AddSilverback()
+    .WithConnectionToMessageBroker(options => options.AddKafka())
+    .AddKafkaEndpoints(endpoints =>
+    {
+        endpoints.Configure(config => { config.BootstrapServers = configuration.Connection.BootstrapServers; });
+
+        foreach (var inbound in configuration.Consumer.Inbounds)
+        {
+            var messageType = MessageTypeRegistry.GetMessageType(inbound.MessageType);
+            if (messageType == null)
+                throw new InvalidOperationException($"Message type '{inbound.MessageType}' not found.");
+
+            if (!Enum.TryParse<AutoOffsetReset>(inbound.AutoOffsetReset, true, out var autoOffsetReset))
+                throw new ArgumentException($"Invalid AutoOffsetReset value: {inbound.AutoOffsetReset}");
+
+            var serializerType = typeof(NewtonsoftJsonMessageSerializer<>).MakeGenericType(messageType);
+            var serializer = Activator.CreateInstance(serializerType) as IMessageSerializer
+                                ?? throw new InvalidOperationException(
+                                    $"Failed to create serializer for type {messageType}");
+
+            endpoints.AddInbound(messageType, endpoint =>
+            {
+                endpoint.SkipNullMessages();
+                endpoint.ConsumeFrom(inbound.Topics)
+                    .Configure(config =>
+                    {
+                        config.GroupId = configuration.Connection.GroupId;
+                        config.AutoOffsetReset = autoOffsetReset;
+                    })
+                    .OnError(policy =>
+                    {
+                        policy.Retry(
+                            configuration.Retry.Attempts,
+                            TimeSpan.FromSeconds(configuration.Retry.IntervalInSeconds)
+                        );
+                        policy.MoveToKafkaTopic(moveEndpoint => { moveEndpoint.ProduceTo(inbound.TopicError); });
+                        policy.Skip();
+                    })
+                    .DeserializeUsing(serializer);
+            });
+        }
+    })
+    .AddScopedSubscriber<OrderCreatedConsumer>();
+```
+
+**After (5.x):**
+
+```csharp
+services
+    .AddSilverback()
+    .WithConnectionToMessageBroker(options => options.AddKafka())
+    .AddKafkaClients(clients =>
+    {
+        clients.WithBootstrapServers(configuration.Connection.BootstrapServers);
+
+        foreach (var inbound in configuration.Consumer.Inbounds)
+        {
+            var messageType = AppDomain.CurrentDomain
+                .GetAssemblies()
+                .SelectMany(a => a.GetTypes())
+                .FirstOrDefault(t => string.Equals(t.Name, inbound.MessageType, StringComparison.OrdinalIgnoreCase));
+
+            if (messageType is null)
+                throw new ArgumentException($"Message type not found: {inbound.MessageType}");
+
+            if (!Enum.TryParse<AutoOffsetReset>(inbound.AutoOffsetReset, true, out var autoOffsetReset))
+                throw new ArgumentException($"Invalid AutoOffsetReset value: {inbound.AutoOffsetReset}");
+
+            clients.AddConsumer(consumer =>
+            {
+                consumer.WithGroupId(configuration.Connection.GroupId);
+                consumer.WithAutoOffsetReset(autoOffsetReset);
+
+                consumer.Consume(endpoint =>
+                {
+                    endpoint.DisableMessageValidation();
+                    endpoint.ConsumeFrom(inbound.Topic);
+                    endpoint.UseDefaultErrorPolicy(inbound.TopicError, configuration.Retry.Attempts, configuration.Retry.IntervalInSeconds);
+                    endpoint.DeserializeJsonDefault(messageType);
+                });
+            });
+
+            // Required for the producer that forwards messages to the error topic
+            clients.AddProducer(producer =>
+            {
+                producer.Produce(endpoint => endpoint.ProduceTo(inbound.TopicError));
+            });
+        }
+    })
+    .AddScopedSubscriber<OrderCreatedSubscriber>();
+```
+
+## Illustrative Benchmark
+
+Measured by publishing 1,000 messages to a Kafka topic in a `foreach` loop, same infrastructure for both versions:
+
+**4.x:**
+
+| Method                        |    Mean |   Error |  StdDev | Ratio |      Gen0 | Allocated | Alloc Ratio |
+| ----------------------------- | ------: | ------: | ------: | ----: | --------: | --------: | ----------: |
+| `PublishAsync` inside foreach | 15.62 s | 0.046 s | 0.038 s |  1.00 | 3000.0000 |  20.16 MB |        1.00 |
+
+**5.x:**
+
+| Method                        |         Mean |     Error |    StdDev | Ratio |      Gen0 |     Gen1 | Allocated | Alloc Ratio |
+| ----------------------------- | -----------: | --------: | --------: | ----: | --------: | -------: | --------: | ----------: |
+| `PublishAsync` inside foreach | 15,623.57 ms | 30.528 ms | 28.556 ms | 1.000 | 1000.0000 |        - |   6.29 MB |        1.00 |
+| `WrapAndPublishBatchAsync`    |     17.84 ms |  0.362 ms |  1.056 ms | 0.001 |  562.5000 | 281.2500 |   3.41 MB |        0.54 |
+
+> `WrapAndPublishBatchAsync` was introduced in 5.0.0, so there is no 4.x baseline for it. Batch publishing shows a substantial allocation and throughput advantage over per-message `PublishAsync` — prefer it for bulk-publish scenarios.
+
+## Summary
+
+| Aspect                | Recommendation                                               |
+| --------------------- | ------------------------------------------------------------ |
+| Target framework      | 5.x requires `net10`                                         |
+| RabbitMQ users        | Stay on 4.x, or migrate off Silverback for RabbitMQ          |
+| `IPublisher` lifetime | Now `Transient` — safe to inject into `Singleton` services   |
+| Bulk publishing       | Prefer `WrapAndPublishBatchAsync` over a `PublishAsync` loop |
+| Serialization         | Default moved to `System.Text.Json`                          |

--- a/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/references/minimal-apis.md
+++ b/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/references/minimal-apis.md
@@ -1,0 +1,157 @@
+# ASP.NET Core 10 & Minimal APIs
+
+ASP.NET Core 10 brings significant improvements to Minimal APIs, OpenAPI generation, and security. Load this reference when building or reviewing Minimal API endpoints, OpenAPI configuration, or Blazor components targeting .NET 10.
+
+## Built-in Validation in Minimal APIs
+
+ASP.NET Core 10 now includes **native validation** for Minimal APIs, removing the need for manual validation or libraries like FluentValidation for simple cases.
+
+**Before (manual validation):**
+
+```csharp
+app.MapPost("/api/upload", (UploadRequest request) =>
+{
+    if (string.IsNullOrEmpty(request.SystemCode))
+        return Results.BadRequest("System code is required");
+
+    if (request.Data == null || request.Data.Length == 0)
+        return Results.BadRequest("Data is required");
+
+    // logic...
+    return Results.Ok();
+});
+```
+
+**After (built-in validation with DataAnnotations):**
+
+```csharp
+public class UploadRequest
+{
+    [Required(ErrorMessage = "System code is required")]
+    public string SystemCode { get; set; }
+
+    [Required(ErrorMessage = "Data is required")]
+    [MinLength(1)]
+    public byte[] Data { get; set; }
+}
+
+// Validation is applied automatically
+app.MapPost("/api/upload", (UploadRequest request) =>
+{
+    // request has already been validated automatically
+    return Results.Ok();
+});
+```
+
+## Native OpenAPI 3.1
+
+.NET 10 generates OpenAPI 3.1 documentation **natively**, without Swashbuckle. It can be paired with UIs like **Scalar** or **Redoc**.
+
+**Configuration with Scalar (Swagger UI alternative):**
+
+```csharp
+// Program.cs
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();              // generates /openapi/v1.json
+    app.MapScalarApiReference();   // interactive UI at /scalar
+}
+```
+
+**Configuration with Swagger UI (keeping compatibility):**
+
+```csharp
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+    app.UseSwaggerUI(options =>
+    {
+        options.SwaggerEndpoint("/openapi/v1.json", "API v1");
+    });
+}
+```
+
+### OpenAPI 3.1 is now the default
+
+.NET 10 generates OpenAPI 3.1 documents by default. This can break tooling or client generators that still expect OpenAPI 3.0.
+
+**To keep OpenAPI 3.0 (if needed):**
+
+```csharp
+builder.Services.AddOpenApi(options =>
+{
+    options.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi3_0;
+});
+```
+
+### `WithOpenApi()` is deprecated
+
+The `WithOpenApi()` extension method is deprecated (warning `ASPDEPR002`).
+
+**Before:**
+
+```csharp
+app.MapGet("/api/items", () => Results.Ok())
+   .WithOpenApi();
+```
+
+**After:**
+
+```csharp
+app.MapGet("/api/items", () => Results.Ok())
+   .WithOpenApi(operation =>
+   {
+       // use AddOpenApiOperationTransformer() for custom transforms
+       return operation;
+   });
+```
+
+Or, preferably, rely on the native OpenAPI pipeline:
+
+```csharp
+builder.Services.AddOpenApi();
+```
+
+## Passkey Support for Identity
+
+ASP.NET Core 10 adds **passkey** support for authentication via ASP.NET Core Identity, aligned with the WebAuthn/FIDO2 standards.
+
+## Blazor
+
+- **Script served as a static web asset**: the Blazor script is served as a static asset with automatic compression and fingerprinting.
+- **`QuickGrid` `RowClass`**: apply CSS classes to grid rows conditionally.
+
+```csharp
+<QuickGrid Items="@files" RowClass="@GetRowClass">
+    <PropertyColumn Property="@(f => f.FileName)" Title="File" />
+    <PropertyColumn Property="@(f => f.CreatedAt)" Title="Date" />
+</QuickGrid>
+
+@code {
+    private string GetRowClass(FileRecord file) =>
+        file.IsActive ? "row-highlight" : "";
+}
+```
+
+## WebSocketStream and TLS 1.3
+
+- **`WebSocketStream`**: a simplified API for working with WebSockets through a `Stream`.
+- **TLS 1.3**: native support on macOS (previously available only on Linux/Windows).
+
+## Summary
+
+| Feature                | Impact                                |
+| ---------------------- | ------------------------------------- |
+| Built-in validation    | Less manual code in Minimal APIs      |
+| Native OpenAPI 3.1     | Replaces Swashbuckle for new projects |
+| Passkeys               | Modern, passwordless authentication   |
+| Blazor improvements    | Better performance and DX             |
+| Cross-platform TLS 1.3 | Improved security                     |

--- a/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/references/performance.md
+++ b/extensions/dotnet-10-best-practices/skills/dotnet10-best-practices/references/performance.md
@@ -1,0 +1,280 @@
+# Performance & Runtime (.NET 10)
+
+.NET 10 is described by Microsoft as the "fastest .NET yet." Many improvements are automatic — you get them just by retargeting the framework, with no code changes. Load this reference when evaluating performance-sensitive code, JSON serialization, or class design for a .NET 10 target.
+
+## LINQ: Reduced Abstraction Overhead
+
+The overhead of using `IEnumerable<T>` (vs. hand-written loops) dropped drastically:
+
+| Version | Abstraction overhead |
+| ------- | -------------------- |
+| .NET 9  | ~83%                 |
+| .NET 10 | **~10%**             |
+
+Data pipelines like `Where().Select().ToList()` get significantly faster with no code changes:
+
+```csharp
+// This code gets ~15% faster just by migrating to .NET 10
+var activeItems = items
+    .Where(i => i.IsActive)
+    .Select(i => new { i.Id, i.Name })
+    .ToList();
+```
+
+## `System.Text.Json`: 2-3x Faster
+
+With **source generators** and **NativeAOT**, JSON serialization is 2-3x faster.
+
+**Source generator configuration:**
+
+```csharp
+// Define the serialization context
+[JsonSerializable(typeof(ApiResult<FileRecord>))]
+[JsonSerializable(typeof(ApiResult<bool>))]
+[JsonSerializable(typeof(UploadDownloadDto))]
+public partial class ApiJsonContext : JsonSerializerContext { }
+
+// Register in Program.cs
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0, ApiJsonContext.Default);
+});
+```
+
+> Benefit: fewer allocations, faster serialization, and **required** for NativeAOT.
+
+### .NET 8 vs .NET 10 comparison
+
+| Metric                            | .NET 8   | .NET 10            |
+| --------------------------------- | -------- | ------------------ |
+| JSON Schema validation            | baseline | **~29% faster**    |
+| Serialization (source gen)        | 1x       | **2-3x faster**    |
+| Deserialization with `PipeReader` | N/A      | **Native support** |
+
+## JIT Compiler
+
+The .NET 10 JIT includes several optimizations:
+
+- **Better inlining** — more methods inlined automatically.
+- **Devirtualization** — virtual calls resolved at compile time (especially with `sealed` classes).
+- **Loop inversion** — more efficient loops.
+- **AVX10.2** — support for newer SIMD instructions.
+- **Struct arguments** — optimized struct passing.
+
+## NativeAOT
+
+Improvements for AOT deployment scenarios:
+
+- Lower memory footprint.
+- Faster startup.
+- Better compatibility with existing libraries.
+
+## Post-Quantum Cryptography
+
+.NET 10 introduces **ML-DSA** (Module-Lattice Digital Signature Algorithm) support, preparing applications for the post-quantum era:
+
+```csharp
+using System.Security.Cryptography;
+
+// Generate an ML-DSA key
+using var mlDsa = MLDsa.GenerateKey(MLDsaAlgorithm.MLDsa65);
+
+// Sign data
+byte[] signature = mlDsa.SignData(data);
+
+// Verify a signature
+bool valid = mlDsa.VerifyData(data, signature);
+```
+
+## `TimeProvider`: Testable Time
+
+`TimeProvider` is an abstraction that replaces `DateTime.UtcNow` with an injectable, testable time source.
+
+**Before:**
+
+```csharp
+public class ReportService
+{
+    public string GetOutputDirectory()
+    {
+        // Hard to test - depends on the system clock
+        string year = DateTime.Today.Year.ToString();
+        string month = DateTime.Today.Month.ToString();
+        string day = DateTime.Today.Day.ToString();
+        return $"{year}/{month}/{day}/";
+    }
+}
+```
+
+**After:**
+
+```csharp
+public class ReportService(TimeProvider timeProvider)
+{
+    public string GetOutputDirectory()
+    {
+        var today = timeProvider.GetLocalNow().Date;
+        return $"{today.Year}/{today.Month}/{today.Day}/";
+    }
+}
+
+// DI registration:
+builder.Services.AddSingleton(TimeProvider.System);
+
+// In tests:
+var fakeTime = new FakeTimeProvider(new DateTimeOffset(2026, 3, 3, 0, 0, 0, TimeSpan.Zero));
+var service = new ReportService(fakeTime);
+// GetOutputDirectory() always returns "2026/3/3/"
+```
+
+## Summary of Automatic Gains
+
+Obtained **just by migrating** to .NET 10, no code changes required:
+
+- LINQ ~15% faster on data pipelines.
+- JSON Schema ~29% faster.
+- JIT with better inlining and devirtualization.
+- Generally lower memory usage.
+
+Gains that **require code changes** to realize:
+
+- Source generators for `System.Text.Json`.
+- `TimeProvider` for testable code.
+- Sealed classes for devirtualization (see below).
+
+## Sealed Classes
+
+`sealed` classes cannot be inherited, which clearly signals design intent and enables JIT performance optimizations.
+
+### Why use `sealed`?
+
+**1. Design intent** — most classes are not designed to be inherited. Marking them `sealed` communicates that explicitly.
+
+**2. Performance: JIT devirtualization** — when a class is `sealed`, the JIT knows there are no subclasses and can optimize virtual method calls, eliminating the v-table lookup.
+
+**Comparative benchmark:**
+
+| Scenario               | Non-sealed | Sealed       |
+| ---------------------- | ---------- | ------------ |
+| Virtual method call    | ~0.45 ns   | **~0.01 ns** |
+| Type check (`is`/`as`) | ~0.20 ns   | **~0.04 ns** |
+
+> The absolute difference is small (nanoseconds), but in hot paths with millions of calls the impact is significant.
+
+**3. Encapsulation** — sealed classes prevent accidental or unwanted inheritance, avoiding behavior being overridden incorrectly.
+
+### Where to apply it
+
+**Seal by default** — any class not designed for inheritance should be `sealed`:
+
+**Before:**
+
+```csharp
+public class FileUploadService : IFileUploadService
+{
+    private readonly IFileUploadRepository _repository;
+    private readonly IMessagePublisher _messaging;
+
+    public FileUploadService(IFileUploadRepository repository, IMessagePublisher messaging)
+    {
+        _repository = repository;
+        _messaging = messaging;
+    }
+
+    public async Task<bool> DeleteFile(Guid fileId, string systemCode, CancellationToken ct)
+    {
+        // ...
+    }
+}
+```
+
+**After:**
+
+```csharp
+public sealed class FileUploadService(IFileUploadRepository repository, IMessagePublisher messaging) : IFileUploadService
+{
+    public async Task<bool> DeleteFile(Guid fileId, string systemCode, CancellationToken ct)
+    {
+        // ...
+    }
+}
+```
+
+> This example also uses the C# 12 **primary constructor** alongside standard `sealed`.
+
+### Types of classes that should be sealed
+
+- **Services** (`FileUploadService`, `EmailService`, etc.)
+- **Repositories** (`FileUploadRepository`, etc.)
+- **DTOs** and **ViewModels** (`UploadDownloadDto`, etc.)
+- **Helpers and extension classes**
+- **Handlers and middlewares**
+- **Validators**
+
+### Where NOT to apply it
+
+- **Abstract base classes** designed to be inherited (`abstract class`).
+- **Classes that are part of a planned inheritance hierarchy**.
+- **Classes mocked in tests without an interface** — if the class implements an **interface** (`IFileUploadService`), it can be `sealed` without issue since mocks target the interface.
+
+```csharp
+// This works fine with sealed:
+public sealed class FileUploadService : IFileUploadService { }
+
+// In tests:
+var mock = new Mock<IFileUploadService>();  // mocking the interface, not the class
+```
+
+### Analyzer CA1852
+
+.NET ships the **CA1852** analyzer, which automatically detects classes that could be sealed. Enable it in `.editorconfig`:
+
+```ini
+[*.cs]
+dotnet_diagnostic.CA1852.severity = suggestion
+```
+
+Or, to make it a warning:
+
+```ini
+[*.cs]
+dotnet_diagnostic.CA1852.severity = warning
+```
+
+### Sealed override methods
+
+Besides classes, `override` methods can also be marked `sealed` to stop subclasses from overriding them further:
+
+```csharp
+public class BaseService
+{
+    public virtual void Process() { }
+}
+
+public class MyService : BaseService
+{
+    public sealed override void Process()
+    {
+        // No one can override this method further
+    }
+}
+```
+
+### Recommended pattern
+
+Adopt **"sealed by default"** across projects:
+
+1. Every new class is `sealed` by default.
+2. Remove `sealed` only when inheritance is **explicitly required**.
+3. Enable the CA1852 analyzer as `suggestion` or `warning`.
+4. Classes that implement interfaces can (and should) be `sealed`.
+
+### Summary
+
+| Aspect                                         | Recommendation                      |
+| ---------------------------------------------- | ----------------------------------- |
+| Services, repositories, DTOs, helpers          | **Always sealed**                   |
+| Abstract classes                               | Never sealed                        |
+| Classes with an interface                      | Sealed (mock via the interface)     |
+| Classes without an interface that need mocking | Don't seal, or extract an interface |
+| General rule                                   | **Sealed by default**               |


### PR DESCRIPTION
Adds a new Junie extension covering .NET 10 / C# 14 migration and best practices.

Covers:
- C# 14 language features (Extension Members, field keyword, and more)
- ASP.NET Core 10 (native Minimal API validation, OpenAPI 3.1)
- Performance guidance (LINQ, System.Text.Json source generators, sealed-by-default)
- .csproj, Dockerfile, CI pipeline, and Helm migration steps
- Known third-party breaking changes (FluentFTP, OpenTelemetry, Silverback 4.x → 5.x)

Follows the existing hub-and-spoke SKILL.md + references/ layout used by sql-engineer and redis-engineer, and registers the extension in .junie-extension/marketplace.json so it's discoverable.